### PR TITLE
added validation to check uniqueness of identifiers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,7 +48,7 @@ def system_design_question_data(dir)
 end
 
 def validate_question_data(data)
-  # rule: coding idenfier must be unique
+  # rule: coding identifier must be unique
   unless !$unique_coding_identifiers.include?(data['identifier'])
     raise "#{data['identifier']} is a repeated question. Only add unique questions"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -48,6 +48,12 @@ def system_design_question_data(dir)
 end
 
 def validate_question_data(data)
+  # rule: coding idenfier must be unique
+  unless !$unique_coding_identifiers.include?(data['identifier'])
+    raise "#{data['identifier']} is a repeated question. Only add unique questions"
+  end
+  $unique_coding_identifiers.add(data['identifier'])
+
   # rule 1: difficulty must be one of ["easy", "medium", "hard"]
   unless ["easy", "medium", "hard"].include?(data["difficulty"])
     raise "In #{data['identifier']}, #{data['difficulty']} is not a valid difficulty, must be one of ['easy', 'medium', 'hard']"
@@ -71,6 +77,7 @@ end
 desc "generate data from coding questions. DRY_RUN=true rake generate_coding_json"
 task :generate_coding_json do
   data = {}
+  $unique_coding_identifiers = Set.new
   dirs = Dir.glob("coding/**")
   coding_questions = dirs.map {|dir| coding_question_data(dir)}
   data[:questions] = coding_questions

--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ def validate_question_data(data)
   unless !$unique_coding_identifiers&.include?(data['identifier'])
     raise "#{data['identifier']} is a repeated question. Only add unique questions. #{$unique_coding_identifiers} is our list of problems"
   end
-  $unique_coding_identifiers.add(data['identifier'])
+  $unique_coding_identifiers&.add(data['identifier'])
 
   # rule 1: difficulty must be one of ["easy", "medium", "hard"]
   unless ["easy", "medium", "hard"].include?(data["difficulty"])

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'yaml'
 require 'json'
+require 'set'
 
 GITHUB_CDN = 'https://raw.githubusercontent.com/HackerPen/tech-interview-questions'
 GITHUB_BRANCH = 'main'
@@ -69,11 +70,14 @@ def validate_question_data(data)
 end
 
 def check_identifier_uniqueness(coding_questions)
-  all_identifiers = coding_questions.map{|question| question['identifier']}
-  duplicate_identifiers = all_identifiers.group_by{ |e| e }.select { |k, v| v.size > 1 }.keys
-  if duplicate_identifiers.size > 0
-    raise "duplicate identifiers detected: #{duplicate_identifiers.join(', ')}"
-  end
+  all_identifiers = Set.new
+  for question in coding_questions do
+    q_id = question['identifier']
+    if all_identifiers.include?(q_id)
+      raise "duplicate identifiers detected: #{q_id}"
+    end
+      all_identifiers.add(q_id)
+    end
 end
 
 desc "generate data from coding questions. DRY_RUN=true rake generate_coding_json"

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'yaml'
 require 'json'
+require 'set'
 
 GITHUB_CDN = 'https://raw.githubusercontent.com/HackerPen/tech-interview-questions'
 GITHUB_BRANCH = 'main'

--- a/Rakefile
+++ b/Rakefile
@@ -50,8 +50,8 @@ end
 
 def validate_question_data(data)
   # rule: coding identifier must be unique
-  unless !$unique_coding_identifiers.include?(data['identifier'])
-    raise "#{data['identifier']} is a repeated question. Only add unique questions"
+  unless !$unique_coding_identifiers&.include?(data['identifier'])
+    raise "#{data['identifier']} is a repeated question. Only add unique questions. #{$unique_coding_identifiers} is our list of problems"
   end
   $unique_coding_identifiers.add(data['identifier'])
 


### PR DESCRIPTION
successfully tested with DRY_RUN=true rake generate_coding_json

please check Ruby best practices with my logic:

created global variable set of unique identifiers. If identifier is in set, raise exception. if no exception raised, identifier added to unique set. run time should be O(1) to check and add into set.

def validate_question_data(data)
  # rule: coding identifier must be unique
  unless !$unique_coding_identifiers.include?(data['identifier'])
    raise "#{data['identifier']} is a repeated question. Only add unique questions"
  end
  $unique_coding_identifiers.add(data['identifier'])

